### PR TITLE
Design-view-all-freelancer

### DIFF
--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -46,6 +46,10 @@ export interface Review {
   clientId: string;
 }
 
+export interface PortfolioIndexMap {
+  [freelancerId: string]: number;
+}
+
 const Types = () => {
   return <div>Types</div>;
 };

--- a/src/components/home/freelancerList/freelancerList.styles.ts
+++ b/src/components/home/freelancerList/freelancerList.styles.ts
@@ -1,0 +1,84 @@
+import { styled } from "styled-components";
+
+export const S = {
+  FreelancerListContainer: styled.div`
+    width: 98%;
+    height: 80vh;
+    overflow-y: auto;
+    margin-top: 20px;
+
+    display: grid;
+    grid-template-columns: 455px 455px;
+	  grid-template-rows: 350px 350px;
+    gap: 20px;
+
+     &::-webkit-scrollbar {
+    width: 12px;
+    }
+    &::-webkit-scrollbar-thumb {
+      background-color: #848484;
+      border-radius: 10px;
+      background-clip: padding-box;
+      border: 2px solid transparent;
+    }
+    &::-webkit-scrollbar-track {
+      background-color: #f3f3f3;
+      border-radius: 10px;
+    }
+  `,
+
+  FreelancerList: styled.ul`
+    width: 455px;
+    margin: 10px;
+  `,
+
+  PortfoliothumbNailImageBox: styled.div`
+    width: 455px;
+    height: 250px;
+    border-radius: 15px;
+    background-color: #403E3E;
+    overflow: hidden;
+
+    img{
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+  `,
+
+  PortfolioTitleBox: styled.div`
+    width: 455px;
+    display: flex;
+    justify-content: center;
+    padding: 20px 0;
+  `,
+
+  PortfolioTitle: styled.h6`
+    font-weight: bold;
+  `,
+
+  MiniProfileBox: styled.li`
+    background-color: rgba(0,0,0,0.1);
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    padding: 10px;
+    border-radius: 15px;
+    width: 455px;
+  `,
+
+  PortfolioList: styled.ul`
+  display: flex;
+  width: 455px;
+  overflow: hidden;
+  `,
+
+  indicatorWrapper: styled.div`
+  position: absolute;
+  bottom: 20%;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  `
+}


### PR DESCRIPTION
## 개요 🔎

프리랜서 마켓 내의 프리랜서 리스트 ui 수정

## 작업사항 📝

전체 영역 그리드 지정하여 한 줄에 두 명의 프리랜서 정보 나오도록 구조잡기
한 프리랜서에게 여러 개의 포트폴리오가 있을 경우 인디케이터로 선택하여 넘어가도록 변경
포트폴리오가 없을 경우 지정된 기본 이미지와 title이 나오게 지정

## 패키지 설치내용 📦

X