### PR TITLE
Feat-search freelancer #20

### DIFF
--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -50,6 +50,15 @@ export interface PortfolioIndexMap {
   [freelancerId: string]: number;
 }
 
+export interface SearchFreelancerProps {
+  onSearch: (keyword: string) => void;
+}
+
+export interface FreelancerListProps {
+  freelancersData: User[];
+}
+
+
 const Types = () => {
   return <div>Types</div>;
 };

--- a/src/components/common/Layout.tsx
+++ b/src/components/common/Layout.tsx
@@ -1,16 +1,26 @@
 import React from "react";
 import Navbar from "./navbar/Navbar";
+import { styled } from "styled-components";
 
 interface LayoutProps {
   children: React.ReactNode;
 }
 const Layout = ({ children }: LayoutProps) => {
   return (
-    <div style={{ display: "flex" }}>
+    <S.LayoutContainer>
       <Navbar />
-      <div style={{ flex: 1, marginLeft: "35px" }}>{children}</div>
-    </div>
+      <div>{children}</div>
+    </S.LayoutContainer>
   );
 };
 
 export default Layout;
+
+const S = {
+  LayoutContainer: styled.div`
+    width: 90vw;
+    height: 100vh;
+    margin: 0 auto;
+    display: flex;
+  `
+}

--- a/src/components/common/navbar/Navbar.tsx
+++ b/src/components/common/navbar/Navbar.tsx
@@ -40,12 +40,11 @@ export default Navbar;
 const S = {
   SidebarWrapper: styled.div`
     position: sticky;
-    left: 30px;
     display: flex;
     flex-direction: column;
     background-color: #333333f7;
     color: white;
-    width: 200px;
+    width: 330px;
     padding: 20px;
     z-index: 999;
     height: 100vh;

--- a/src/components/home/freelancerList/FreelancerList.tsx
+++ b/src/components/home/freelancerList/FreelancerList.tsx
@@ -1,13 +1,16 @@
 import React, { useEffect, useState } from 'react'
 import { useQuery } from '@tanstack/react-query';
-import { getFreelancers } from '../../../api/User';
+// import { getFreelancers } from '../../../api/User';
 import { getPortfolios } from '../../../api/Portfolio';
 import { S } from './freelancerList.styles';
-import { PortfolioIndexMap } from '../../../Types';
+import { FreelancerListProps, PortfolioIndexMap} from '../../../Types';
+import {FaHandshakeSimple} from "react-icons/fa6"
 
-const FreelancerList = () => {
+
+
+const FreelancerList = ({freelancersData}:FreelancerListProps) => {
   const [selectedPortfolioIndex, setSelectedPortfolioIndex] = useState<PortfolioIndexMap>({});
-  const {data: freelancersData, error:freelancersError, isLoading:freelancersIsLoading} = useQuery(['freelancersData'], getFreelancers);
+  // const {data: freelancersData, error:freelancersError, isLoading:freelancersIsLoading} = useQuery(['freelancersData'], getFreelancers);
   const {data: portfoliosData, error: portfoliosError, isLoading: portfoliosIsLoading} = useQuery(['portfoliosData'], getPortfolios, {enabled: !!freelancersData});
   
   // 첫 번째 포트폴리오 항목을 보이도록 설정
@@ -21,12 +24,12 @@ const FreelancerList = () => {
     }
   }, [freelancersData]);
 
-  if(freelancersIsLoading){
-    return <span>freelancers Loading..</span>
-  }
-  if(freelancersError){
-    return <span>freelancers Error..</span>
-  }
+  // if(freelancersIsLoading){
+  //   return <span>freelancers Loading..</span>
+  // }
+  // if(freelancersError){
+  //   return <span>freelancers Error..</span>
+  // }
 
   if(portfoliosIsLoading){
     return <span>portfolios Loading..</span>
@@ -94,12 +97,12 @@ const FreelancerList = () => {
                     )}
 
                   <S.MiniProfileBox>
-                    <div>
-                      <span>{freelanceritem.name}</span>
-                      <span>{freelanceritem.workField}</span>
-                      <span>{freelanceritem.workExp}</span>
-                    </div>
-                    <button>제안하기</button>
+                    <S.FreelancerContentBox>
+                      <S.FreelancerName>{freelanceritem.name}</S.FreelancerName>
+                      <S.FreelancerContent>{freelanceritem.workField}</S.FreelancerContent>
+                      <S.FreelancerContent>{String(freelanceritem.workExp)}년차</S.FreelancerContent>
+                    </S.FreelancerContentBox>
+                    <S.SuggestButton><FaHandshakeSimple size="25"/></S.SuggestButton>
                   </S.MiniProfileBox>
                 </S.FreelancerList>
           </div>

--- a/src/components/home/freelancerList/freelancerList.styles.ts
+++ b/src/components/home/freelancerList/freelancerList.styles.ts
@@ -2,13 +2,14 @@ import { styled } from "styled-components";
 
 export const S = {
   FreelancerListContainer: styled.div`
-    width: 98%;
+    width: 100%;
     height: 80vh;
-    overflow-y: auto;
+    overflow-y: scroll;
     margin-top: 20px;
+    padding: 0 20px;
 
     display: grid;
-    grid-template-columns: 455px 455px;
+    grid-template-columns: 475px 475px;
 	  grid-template-rows: 350px 350px;
     gap: 20px;
 
@@ -63,7 +64,7 @@ export const S = {
     flex-direction: row;
     justify-content: space-between;
     align-items: center;
-    padding: 10px;
+    padding: 5px 10px;
     border-radius: 15px;
     width: 455px;
   `,
@@ -80,5 +81,39 @@ export const S = {
   left: 50%;
   transform: translateX(-50%);
   display: flex;
+  `,
+
+  SuggestButton: styled.button`
+    border: none;
+    background-color:transparent;
+    cursor: pointer;
+    transition: transform .2s ease-in-out;
+
+    &:hover {
+      transform: scale(1.2);
+    }
+    &:hover:not(:hover) {
+    transform: scale(1);
+  }
+  `,
+
+  FreelancerContentBox: styled.div`
+    display: flex;
+    align-items: end;
+
+    span{
+      margin: 0 3px;
+    }
+  `,
+
+  FreelancerName: styled.span`
+    font-weight: bold;
+    color: #045FB4;
+    font-size: 18px;
+    margin-right: 5px;
+  `,
+
+  FreelancerContent: styled.span`
+    font-size: 14px;
   `
 }

--- a/src/components/home/freelancerMarket/FreelancerMarket.tsx
+++ b/src/components/home/freelancerMarket/FreelancerMarket.tsx
@@ -1,0 +1,48 @@
+import React, { useState } from 'react'
+import SearchFreelancer from '../searchFreelancer/SearchFreelancer'
+import FreelancerList from '../freelancerList/FreelancerList'
+import { useQuery } from '@tanstack/react-query';
+import { getFreelancers } from '../../../api/User';
+import { User } from '../../../Types';
+
+const FreelancerMarket = () => {
+  const [searchedKeyword, setSearchedKeyword] = useState<string | number>('');
+  
+  const {data: freelancersData, error: freelancersError, isLoading: freelancersIsLoading} = useQuery(['freelancersData'], getFreelancers);
+  if(freelancersIsLoading){
+    return <span>freelancers Loading..</span>
+  }
+  if(freelancersError){
+    return <span>freelancers Error..</span>
+  }
+  
+  const handleSearch = (keyword:string) => {
+    setSearchedKeyword(keyword);
+  }
+
+  let filteredFreelancers = freelancersData;
+
+  if (freelancersData) {
+    filteredFreelancers = freelancersData?.filter(freelancer => {
+      const lowerCaseSearch = String(searchedKeyword).toLowerCase(); // 검색어를 소문자로 변경
+      const workExp = String(freelancer.workExp); // workExp도 문자열로 변경
+  
+      return (
+        (typeof searchedKeyword === 'string' &&
+          (freelancer.name.toLowerCase().includes(lowerCaseSearch) ||
+            freelancer.workField?.toLowerCase().includes(lowerCaseSearch))) ||
+        (typeof searchedKeyword === 'number' && workExp === lowerCaseSearch) || // workExp를 문자열로 변경하여 검색어와 비교
+        (typeof searchedKeyword === 'string' && workExp === lowerCaseSearch) // 숫자 검색어도 workExp와 비교
+      );
+    });
+  }
+
+  return (
+    <>
+      <SearchFreelancer onSearch={handleSearch}/>
+      <FreelancerList freelancersData={filteredFreelancers as User[]}/>
+    </>
+  )
+}
+
+export default FreelancerMarket

--- a/src/components/home/searchFreelancer/SearchFreelancer.tsx
+++ b/src/components/home/searchFreelancer/SearchFreelancer.tsx
@@ -1,0 +1,34 @@
+import React, { ChangeEvent, useEffect, useRef, useState } from 'react'
+import { S } from './searchFreelancer.styles'
+import {MdPersonSearch} from 'react-icons/md'
+import { SearchFreelancerProps } from '../../../Types';
+
+
+const SearchFreelancer = ({onSearch} : SearchFreelancerProps) => {
+  const [searchKeyword, setSearchKeyword] = useState('');
+  const searchInput = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    searchInput.current?.focus();
+  },[])
+
+  const HandleSearchKeywordOnChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setSearchKeyword(e.target.value);
+  }
+
+  const handleSearchButtonClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    onSearch(searchKeyword);
+  }
+
+  return (
+    <S.searchContainer>
+      <S.searchForm>
+        <S.searchInput ref={searchInput} type='text' value={searchKeyword} onChange={HandleSearchKeywordOnChange} placeholder='검색어를 입력해주세요.'></S.searchInput>
+        <S.searchInputButton onClick={handleSearchButtonClick}><MdPersonSearch size='25'/></S.searchInputButton>
+      </S.searchForm>
+    </S.searchContainer>
+  )
+}
+
+export default SearchFreelancer

--- a/src/components/home/searchFreelancer/searchFreelancer.styles.ts
+++ b/src/components/home/searchFreelancer/searchFreelancer.styles.ts
@@ -1,0 +1,36 @@
+import { styled } from "styled-components";
+
+export const S = {
+  searchContainer: styled.div`
+    margin: 20px 20px 0 30px;
+    width: 80%;
+  `,
+
+  searchForm: styled.form`
+    width: 100%;
+    position: relative;
+  `,
+
+  searchInput: styled.input`
+    width: 100%;
+    padding: 15px;
+    border: none;
+    background-color: rgba(0,0,0,0.1);
+    border-radius: 50px;
+
+    &:focus { 
+      outline: none;
+    }
+  `,
+
+  searchInputButton: styled.button`
+    position: absolute;
+    top: 50%;
+    right: 2%;
+    transform: translateY(-50%);
+    border: none;
+    background-color: transparent;
+    cursor: pointer;
+    opacity: 0.5;
+  `
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,16 +1,13 @@
 import React from "react";
+import FreelancerMarket from "../components/home/freelancerMarket/FreelancerMarket";
 
-import FreelancerList from "../components/home/freelancerList/FreelancerList";
-
-// 마켓플레이스 페이지
+// 프리랜서 구인 페이지
 
 const Home = () => {
   return (
-
     <>
-      <FreelancerList />
+      <FreelancerMarket />
     </>
-
   );
 };
 


### PR DESCRIPTION
## 개요 🔎

프리랜서 구인 페이지의 프리랜서 마켓 탭 내부에서 프리랜서 검색 기능 구현 후
팀원들과 code merge

## 작업사항 📝

- 프리랜서 마켓 탭에서 프리랜서 이름. 필드, 연차 정보에 대한 검색 기능 구현
- 추가 작업 - ui
(1) (1) Layout.tsx → 스타일 내용 수정 및 인라인 스타일에서 스타일
컴포넌트로 변경
(2) Navbar.styles.ts → width 수정
(3) freelancerList → 프리랜서 정보 스타일 수정 / 제안하기 버튼 아이콘
추가 / react-icon 설치

## 패키지 설치내용 📦

react-icons