### PR TITLE
Refacor-Refactoring the coded freelancerMarket #62

### DIFF
--- a/src/api/Project.ts
+++ b/src/api/Project.ts
@@ -18,6 +18,17 @@ export const getProjectByClient = async (id: string): Promise<Project[]> => {
     .eq("clientId", id);
   return projects as Project[];
 };
+export const getProjectByClientWithBeforeProgress = async (
+  clientId: string
+): Promise<Project[]> => {
+  const { data: projects } = await supabase
+    .from("projects")
+    .select("*")
+    .eq("clientId", clientId)
+    .eq("status", "진행 전");
+
+  return projects as Project[];
+};
 
 export const addProject = async (newProject: Project): Promise<void> => {
   await supabase

--- a/src/api/User.ts
+++ b/src/api/User.ts
@@ -106,14 +106,13 @@ export const getFreelancersBySort = async (sortLabel: string) => {
       .order(orderByField, { ascending });
     if (error) {
       alert(
-        `사용자 정보를 가져오는 중 오류가 발생했습니다zz.\n ${error.message}`
+        `사용자 정보를 가져오는 중 오류가 발생했습니다.\n ${error.message}`
       );
     }
-    console.log("data==>", data);
     return data;
   } catch (error) {
     throw new Error(
-      `사용자 정보를 가져오는 중 오류가 발생했습니다gg.\n ${error}`
+      `사용자 정보를 가져오는 중 오류가 발생했습니다.\n ${error}`
     );
   }
 };

--- a/src/components/common/searchItemBar/SearchItemBar.tsx
+++ b/src/components/common/searchItemBar/SearchItemBar.tsx
@@ -1,23 +1,23 @@
-import React, { ChangeEvent, useEffect, useRef } from "react";
+import React, { useEffect, useRef } from "react";
 import { S } from "./searchItemBar.styles";
 import { MdPersonSearch } from "react-icons/md";
 import { useSearchKeywordStore } from "src/zustand/useSearchKeywordStore";
+import useInput from "src/hooks/useInput";
 
 const SearchItemBar = () => {
   const searchInput = useRef<HTMLInputElement | null>(null);
-  const { searchKeyword, changeSearchKeyword } = useSearchKeywordStore();
+  const { changeSearchKeyword } = useSearchKeywordStore();
 
   useEffect(() => {
     searchInput.current?.focus();
   }, []);
 
-  const HandleSearchKeywordOnChange = (e: ChangeEvent<HTMLInputElement>) => {
-    changeSearchKeyword(e.target.value);
-  };
-
   const handleSearchButtonClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
+    changeSearchKeyword(searchInputProps.value);
   };
+
+  const searchInputProps = useInput("");
 
   return (
     <S.searchContainer>
@@ -25,8 +25,7 @@ const SearchItemBar = () => {
         <S.searchInput
           ref={searchInput}
           type="text"
-          value={searchKeyword}
-          onChange={HandleSearchKeywordOnChange}
+          {...searchInputProps}
           placeholder="검색어를 입력해주세요."
         ></S.searchInput>
         <S.searchInputButton onClick={handleSearchButtonClick}>

--- a/src/components/home/freelancerMarket/FreelancerMarket.tsx
+++ b/src/components/home/freelancerMarket/FreelancerMarket.tsx
@@ -1,55 +1,17 @@
-import React, { useState, useEffect } from "react";
+import { useState } from "react";
 import FreelancerList from "./freelancerList/FreelancerList";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { getFreelancersBySort } from "../../../api/User";
-import { User } from "../../../Types";
 import SearchItemBar from "../../common/searchItemBar/SearchItemBar";
 import SortFreelancers from "./sortFreelancers/SortFreelancers";
 import { styled } from "styled-components";
 import WorkFieldCategory from "./workFieldCategory/WorkFieldCategory";
-import { Spin } from "antd";
 
 const FreelancerMarket = () => {
-  // const [searchedKeyword, setSearchedKeyword] = useState("");
   const [selectedSortLabel, setSelectedSortLabel] = useState("");
   const [selectedWorkField, setSelectedWorkField] = useState("전체보기");
-  const queryClient = useQueryClient();
 
-  useEffect(() => {
-    if (selectedSortLabel !== "") {
-      queryClient.invalidateQueries(["freelancersData", selectedSortLabel]);
-    }
-  }, [selectedSortLabel]);
-
-  // 라벨을 선택하는 함수를 생성하여 sortFreelancers 컴포넌트로 보내서
-  // 라벨을 가져와서 selectSortLabel에 지정해준다..
   const handleSort = (label: string) => {
     setSelectedSortLabel(label);
   };
-
-  // 미리 모든 정렬 쿼리들을 호출하여 데이터를 가져옴
-  useEffect(() => {
-    const sortLabels = [
-      "경력 높은 순",
-      "경력 낮은 순",
-      "최근 가입 순",
-      "오래된 가입 순",
-      "포트폴리오 많은 순",
-      "포트폴리오 적은 순",
-    ];
-
-    sortLabels.forEach(async (label) => {
-      try {
-        const data = await getFreelancersBySort(label);
-        queryClient.setQueryData(["freelancersData", label], data);
-      } catch (error) {
-        console.error(
-          `라벨 ${label} 데이터를 미리 불러오는 동안 오류 발생:`,
-          error
-        );
-      }
-    });
-  }, [queryClient]);
 
   return (
     <>

--- a/src/components/home/freelancerMarket/freelancerList/FreelancerList.tsx
+++ b/src/components/home/freelancerMarket/freelancerList/FreelancerList.tsx
@@ -1,12 +1,10 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { S } from "./freelancerList.styles";
-
 import { User } from "../../../../Types";
 import FreelancerCard from "./FreelancerCard";
 import { useSearchKeywordStore } from "src/zustand/useSearchKeywordStore";
-import { useQuery } from "@tanstack/react-query";
-import { getFreelancersBySort } from "src/api/User";
 import { Spin } from "antd";
+import useFreelancersQueries from "src/hooks/useFreelancersQueries";
 
 export interface PortfolioIndexMap {
   [freelancerId: string]: number;
@@ -23,54 +21,49 @@ const FreelancerList = ({
 }: FreelancerListProps) => {
   const [selectedPortfolioIndex, setSelectedPortfolioIndex] =
     useState<PortfolioIndexMap>({});
-  const queryKey = ["freelancersData", selectedSortLabel];
   const { searchKeyword } = useSearchKeywordStore();
 
-  // 프리랜서 데이터를 불러온다
-  const {
-    data: freelancersData,
-    error: freelancersError,
-    isLoading: freelancersIsLoading,
-  } = useQuery(queryKey, () => getFreelancersBySort(selectedSortLabel), {
-    staleTime: Infinity,
-    cacheTime: Infinity,
-  });
+  const { freelancersDataBySort, freelancersError, freelancersIsLoading } =
+    useFreelancersQueries(selectedSortLabel);
+
   const [filteredFreelancers, setFilteredFreelancers] = useState<User[]>(
-    freelancersData!
+    freelancersDataBySort!
   );
 
   useEffect(() => {
-    if (freelancersData) {
-      const filteredfreelancerLists = freelancersData?.filter((freelancer) => {
-        // 입력한 키워드가 대문자이든 소문자이든 무조건 소문자로 변경
-        const lowerCaseSearch = String(searchKeyword).toLowerCase();
-        // workExp는 숫자이기 때문에 미리 문자열로 변경
-        const workExp = String(freelancer.workExp);
-        return (
-          freelancer?.name?.toLowerCase().includes(lowerCaseSearch) ||
-          freelancer?.workField?.workField
-            ?.toLowerCase()
-            .includes(lowerCaseSearch) ||
-          freelancer?.workField?.workSmallField
-            ?.toLowerCase()
-            .includes(lowerCaseSearch) ||
-          workExp === searchKeyword
-        );
-      });
+    if (freelancersDataBySort) {
+      const filteredfreelancerLists = freelancersDataBySort?.filter(
+        (freelancer) => {
+          // 입력한 키워드가 대문자이든 소문자이든 무조건 소문자로 변경
+          const lowerCaseSearch = String(searchKeyword).toLowerCase();
+          // workExp는 숫자이기 때문에 미리 문자열로 변경
+          const workExp = String(freelancer.workExp);
+          return (
+            freelancer?.name?.toLowerCase().includes(lowerCaseSearch) ||
+            freelancer?.workField?.workField
+              ?.toLowerCase()
+              .includes(lowerCaseSearch) ||
+            freelancer?.workField?.workSmallField
+              ?.toLowerCase()
+              .includes(lowerCaseSearch) ||
+            workExp === searchKeyword
+          );
+        }
+      );
       setFilteredFreelancers(filteredfreelancerLists);
     }
-  }, [freelancersData, searchKeyword]);
+  }, [freelancersDataBySort, searchKeyword]);
 
   // 첫 번째 포트폴리오 항목을 보이도록 설정
   useEffect(() => {
-    if (freelancersData) {
+    if (freelancersDataBySort) {
       const initialSelectedIndex: PortfolioIndexMap = {};
-      freelancersData.forEach((freelancer) => {
+      freelancersDataBySort.forEach((freelancer) => {
         initialSelectedIndex[freelancer.userId] = 0;
       });
       setSelectedPortfolioIndex(initialSelectedIndex);
     }
-  }, [freelancersData]);
+  }, [freelancersDataBySort]);
 
   if (freelancersIsLoading) {
     return (

--- a/src/components/home/freelancerMarket/freelancerList/freelancerList.styles.ts
+++ b/src/components/home/freelancerMarket/freelancerList/freelancerList.styles.ts
@@ -15,7 +15,7 @@ interface IndicatorProps {
 }
 
 interface PortfolioItemProps {
-  isSelected: boolean;
+  isselected: boolean;
 }
 
 export const S = {
@@ -51,7 +51,7 @@ export const S = {
 
   PortfolioItem: styled.div<PortfolioItemProps>`
     position: relative;
-    display: ${(props) => (props.isSelected ? "block" : "none")};
+    display: ${(props) => (props.isselected ? "block" : "none")};
   `,
 
   PortfoliothumbNailImageBox: styled.div`

--- a/src/components/home/freelancerMarket/freelancerList/oneTouchModal/OneTouchModal.tsx
+++ b/src/components/home/freelancerMarket/freelancerList/oneTouchModal/OneTouchModal.tsx
@@ -1,9 +1,7 @@
 import { Project, User } from "src/Types";
 import FreelancerProfile from "src/components/modal/freelancerInfo/FreelancerProfile";
-
 import { S } from "./oneTouchModal.styles";
-import { useState } from "react";
-import { useSelectProjectStore } from "src/zustand/useSelectProjectStore";
+import { useSelectProjectStore } from "src/zustand/useProjectStore";
 
 interface ApplicantResumeModalProps {
   user: User;
@@ -11,20 +9,13 @@ interface ApplicantResumeModalProps {
 }
 
 const OneTouchModal = ({ user, projectLists }: ApplicantResumeModalProps) => {
-  const [selectedProjectItem, setSelectedProjectItem] =
-    useState<Project | null>();
-  const { setSelectedProjectId } = useSelectProjectStore();
-  const { setSelectedProjectTitle } = useSelectProjectStore();
+  const { selectedProject, setSelectedProject } = useSelectProjectStore();
 
   const handleProjectItemClick = (project: Project) => {
-    if (selectedProjectItem === project) {
-      setSelectedProjectTitle(null);
-      setSelectedProjectId(null);
-      setSelectedProjectItem(null);
+    if (selectedProject === project) {
+      setSelectedProject(null);
     } else {
-      setSelectedProjectTitle(project.title);
-      setSelectedProjectId(project.projectId!);
-      setSelectedProjectItem(project);
+      setSelectedProject(project);
     }
   };
 
@@ -44,7 +35,7 @@ const OneTouchModal = ({ user, projectLists }: ApplicantResumeModalProps) => {
               <S.ProjectItem
                 key={projectItem.projectId}
                 onClick={() => handleProjectItemClick(projectItem)}
-                isSelected={selectedProjectItem === projectItem}
+                isselected={selectedProject === projectItem}
               >
                 <S.ProjectItemTitle>{projectItem.title}</S.ProjectItemTitle>
                 <S.ProjectItemDeadLine>

--- a/src/components/home/freelancerMarket/freelancerList/oneTouchModal/oneTouchModal.styles.ts
+++ b/src/components/home/freelancerMarket/freelancerList/oneTouchModal/oneTouchModal.styles.ts
@@ -25,7 +25,7 @@ export const S = {
     border-top: 1px solid rgba(0, 0, 0, 0.1);
   `,
 
-  ProjectItem: styled.div<{ isSelected?: boolean }>`
+  ProjectItem: styled.div<{ isselected?: boolean }>`
     background-color: rgba(0, 0, 0, 0.1);
     width: 100%;
     height: 75px;
@@ -43,9 +43,9 @@ export const S = {
       background-color: #a9e2f3;
     }
 
-    border: ${({ isSelected }) => (isSelected ? "2px solid #58ACFA" : "none")};
-    background-color: ${({ isSelected }) =>
-      isSelected ? "#a9e2f3" : "rgba(0, 0, 0, 0.1)"};
+    border: ${({ isselected }) => (isselected ? "2px solid #58ACFA" : "none")};
+    background-color: ${({ isselected }) =>
+      isselected ? "#a9e2f3" : "rgba(0, 0, 0, 0.1)"};
   `,
 
   ProjectItemTitle: styled.h4`

--- a/src/components/home/freelancerMarket/workFieldCategory/WorkFieldCategory.tsx
+++ b/src/components/home/freelancerMarket/workFieldCategory/WorkFieldCategory.tsx
@@ -1,5 +1,4 @@
 import { Tabs, TabsProps } from "antd";
-import React from "react";
 import { S } from "./WorkFiledCategory.style";
 
 interface WorkFieldCategoryProps {

--- a/src/components/projectManagement/projectList/ProjectCard.tsx
+++ b/src/components/projectManagement/projectList/ProjectCard.tsx
@@ -16,9 +16,9 @@ interface projectCardProps {
 
 const ProjectCard = ({ project }: projectCardProps) => {
   const { client } = useClientsQueries(project);
-  const { deleteProjectMutation, updateProjectMutation } = useProjectsQueries(
-    project.clientId
-  );
+  const { deleteProjectMutation, updateProjectMutation } = useProjectsQueries({
+    userId: project.clientId,
+  });
 
   const [isDetailModalOpen, setIsDetailModalOpen] = useState(false);
   const [isUpadateModalOpen, setIsUpadateModalOpen] = useState(false);

--- a/src/components/projectManagement/projectList/ProjectList.tsx
+++ b/src/components/projectManagement/projectList/ProjectList.tsx
@@ -10,7 +10,7 @@ import useProjectsQueries from "src/hooks/useProjectsQueries";
 
 const ProjectList = () => {
   const { userId } = useUserStore();
-  const { projects, addProjectMutation } = useProjectsQueries(userId);
+  const { projects, addProjectMutation } = useProjectsQueries({ userId });
   const { newProject } = useProjectStore();
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
 

--- a/src/hooks/useClientsQueries.ts
+++ b/src/hooks/useClientsQueries.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { Project } from "src/Types";
 import { getClientByProject } from "src/api/User";
 

--- a/src/hooks/useFreelancersQueries.ts
+++ b/src/hooks/useFreelancersQueries.ts
@@ -1,0 +1,20 @@
+import { useQuery } from "@tanstack/react-query";
+import { getFreelancersBySort } from "src/api/User";
+
+const useFreelancersQueries = (selectedSortLabel: string) => {
+  const {
+    data: freelancersDataBySort,
+    error: freelancersError,
+    isLoading: freelancersIsLoading,
+  } = useQuery(["freelancersData", selectedSortLabel], () =>
+    getFreelancersBySort(selectedSortLabel)
+  );
+
+  return {
+    freelancersDataBySort,
+    freelancersError,
+    freelancersIsLoading,
+  };
+};
+
+export default useFreelancersQueries;

--- a/src/hooks/usePortfoliosQueries.ts
+++ b/src/hooks/usePortfoliosQueries.ts
@@ -1,0 +1,21 @@
+import { useQuery } from "@tanstack/react-query";
+import { User } from "src/Types";
+import { getPortfolios } from "src/api/Portfolio";
+
+const usePortfoliosQueries = (freelancerItem: User) => {
+  const {
+    data: portfoliosData,
+    error: portfoliosError,
+    isLoading: portfoliosIsLoading,
+  } = useQuery(["portfoliosData"], getPortfolios, {
+    enabled: !!freelancerItem,
+  });
+
+  return {
+    portfoliosData,
+    portfoliosError,
+    portfoliosIsLoading,
+  };
+};
+
+export default usePortfoliosQueries;

--- a/src/hooks/useProjectsQueries.ts
+++ b/src/hooks/useProjectsQueries.ts
@@ -4,15 +4,24 @@ import {
   addProject,
   deleteProject,
   getProjectByClient,
+  getProjectByClientWithBeforeProgress,
   updateProject,
 } from "src/api/Project";
 import { Project } from "src/Types";
 
-const useProjectsQueries = (userId: string) => {
+interface useProjectsQueriesProps {
+  userId?: string;
+  freelancerId?: string;
+}
+
+const useProjectsQueries = ({
+  userId,
+  freelancerId,
+}: useProjectsQueriesProps) => {
   const { data: projects } = useQuery(
     ["projects"],
     async () => {
-      const projectsData = await getProjectByClient(userId);
+      const projectsData = await getProjectByClient(userId as string);
       return projectsData;
     },
     {
@@ -48,11 +57,33 @@ const useProjectsQueries = (userId: string) => {
     }
   );
 
+  const {
+    data: projectDataForSuggestions,
+    isLoading: projectDataForSuggestionsIsLoading,
+    isError: projectDataForSuggestionsIsError,
+    refetch: refetchprojectDataForSuggestions,
+  } = useQuery(
+    ["currentClientprojectLists", freelancerId],
+    () => getProjectByClientWithBeforeProgress(userId as string),
+    {
+      enabled: !!userId,
+      select: (projectLists) =>
+        projectLists?.filter(
+          (projectList) =>
+            !projectList.SuggestedFreelancers?.includes(freelancerId as string)
+        ),
+    }
+  );
+
   return {
     projects,
     addProjectMutation,
     deleteProjectMutation,
     updateProjectMutation,
+    projectDataForSuggestions,
+    projectDataForSuggestionsIsLoading,
+    projectDataForSuggestionsIsError,
+    refetchprojectDataForSuggestions,
   };
 };
 

--- a/src/zustand/useProjectStore.ts
+++ b/src/zustand/useProjectStore.ts
@@ -20,3 +20,13 @@ export const useProjectStore = create<ProjectStore>()((set) => ({
   },
   changeNewProject: (newProject) => set(() => ({ newProject: newProject })),
 }));
+
+type SelectProjectStore = {
+  selectedProject: Project | null;
+  setSelectedProject: (project: Project | null) => void;
+};
+
+export const useSelectProjectStore = create<SelectProjectStore>()((set) => ({
+  selectedProject: null,
+  setSelectedProject: (project) => set(() => ({ selectedProject: project })),
+}));


### PR DESCRIPTION
## 개요 🔎

프리랜서 마켓에서 작업한 영역에 대한 리팩토링 후 팀원들과 code merge

## 작업사항 📝

(1) useQuery select 옵션 사용 수정
(2) 안쓰는 import 및 console, 주석 삭제
(3) isSelected warning 가능하다면 해결하기 - 보류
→ 소문자로 변경했더니 다른 warning이 뜨는데 나중에 해결 할 예정
(4) useInput을 검색에도 사용
(5) hook 사용 - useQuery 사용 부분 빼기
(6) useSelectedProjectStore에서 아이디와 타이틀 다로 보내지말고 프로젝트로 한번에 보내도록 수정
→ useSelectedProjectStore로 하지말고 useProjectStore로 옮기기
→ 추가로 OneTouchModal에서 사용하던 selectedProjectItem state도 제거 됨
(7) 프리랜서 리스트를 정렬 레이블의 모든 종류별로 미리 데이터를 불러오던 로직 삭제

## 패키지 설치내용 📦

X