### PR TITLE
Fix-Modify the React query dependency array #62

### DIFF
--- a/src/hooks/useProjectsQueries.ts
+++ b/src/hooks/useProjectsQueries.ts
@@ -63,7 +63,7 @@ const useProjectsQueries = ({
     isError: projectDataForSuggestionsIsError,
     refetch: refetchprojectDataForSuggestions,
   } = useQuery(
-    ["currentClientprojectLists", freelancerId],
+    ["currentClientprojectLists"],
     () => getProjectByClientWithBeforeProgress(userId as string),
     {
       enabled: !!userId,


### PR DESCRIPTION
## 개요 🔎

react-query dev tools에 currentClientprojectLists react-query가 freelancerId 수만큼 호출되는 이슈 해결

## 작업사항 📝

currentClientprojectLists 리엑트 쿼리 사용시 의존성 배열로 인해 dev Tools에 freelancerId 수만큼 호출되는 이슈 해결
→ 의존성 배열 값 삭제

## 패키지 설치내용 📦

X

