### PR TITLE
Feat-applicant freelancer list, pending freelancer list update #108

### DIFF
--- a/src/api/Project.ts
+++ b/src/api/Project.ts
@@ -86,11 +86,7 @@ export const updateProject = async (
     qualification?: number;
   }
 ): Promise<void> => {
-  await supabase
-    .from("projects")
-    .update(column)
-    .eq("projectId", projectId)
-    .select();
+  await supabase.from("projects").update(column).eq("projectId", projectId).select();
 };
 
 export const getSuggestedFreelancers = async (
@@ -108,9 +104,7 @@ export const getSuggestedFreelancers = async (
     }
     return data as { SuggestedFreelancers: string[] };
   } catch (error) {
-    throw new Error(
-      `제안한 프리랜서 목록을 가져오는 중 오류가 발생했습니다.\n ${error}`
-    );
+    throw new Error(`제안한 프리랜서 목록을 가져오는 중 오류가 발생했습니다.\n ${error}`);
   }
 };
 
@@ -164,15 +158,11 @@ export const getProjectOfFreelancerBySort = async (sortLabel: string) => {
       .order(orderByField, { ascending })
       .eq("status", "진행 전");
     if (error) {
-      alert(
-        `프로젝트 목록을 가져오는 중 오류가 발생했습니다.\n ${error.message}`
-      );
+      alert(`프로젝트 목록을 가져오는 중 오류가 발생했습니다.\n ${error.message}`);
     }
     return data;
   } catch (error) {
-    throw new Error(
-      `프로젝트 목록을 가져오는 중 오류가 발생했습니다.\n ${error}`
-    );
+    throw new Error(`프로젝트 목록을 가져오는 중 오류가 발생했습니다.\n ${error}`);
   }
 };
 
@@ -189,9 +179,7 @@ export const getPendingFreelancers = async (
   return projects as Project[];
 };
 
-export const getOngoingProjects = async (
-  clientId: string
-): Promise<Project[]> => {
+export const getOngoingProjects = async (clientId: string): Promise<Project[]> => {
   const { data: projects } = await supabase
     .from("projects")
     .select("*")
@@ -201,9 +189,7 @@ export const getOngoingProjects = async (
   return projects as Project[];
 };
 
-export const getTerminationedProjects = async (
-  clientId: string
-): Promise<Project[]> => {
+export const getTerminationedProjects = async (clientId: string): Promise<Project[]> => {
   const { data: projects } = await supabase
     .from("projects")
     .select("*")
@@ -243,13 +229,18 @@ export const updateApprovalFreelancer = async (
     .match({ projectId });
 };
 
-/* 신청 및 제안, 보류된 프리랜서 목록 초기화 API */
+/* 지원한 프리랜서&보류한 프리랜서 탭에서 계약된 프리랜서 목록 삭제 API */
 export const deleteVolunteerAndPendingFreelancer = async (
-  projectId: string
+  projectId: string,
+  updateVolunteer: string[],
+  updatePendingFreelancer: string[]
 ) => {
   return await supabase
     .from("projects")
-    .update({ volunteer: [], pendingFreelancer: [], SuggestedFreelancers: [] })
+    .update({
+      volunteer: updateVolunteer,
+      pendingFreelancer: updatePendingFreelancer,
+    })
     .match({ projectId });
 };
 

--- a/src/components/home/manageFreelancersByStatus/ApplicantFreelancerList.tsx
+++ b/src/components/home/manageFreelancersByStatus/ApplicantFreelancerList.tsx
@@ -21,19 +21,28 @@ const ApplicantFreelancerList = () => {
   });
 
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [selectedFreelancer, setSelectedFreelancer] = useState<IUser | null>(
-    null
-  );
+  const [selectedFreelancer, setSelectedFreelancer] = useState<IUser | null>(null);
 
   const updateFreelancer = (
     userId: string,
     projectId: string,
     endDate: string,
-    projectIds: string[]
+    projectIds: string[],
+    volunteer: string[],
+    pendingFreelancer: string[]
   ) => {
     const customProjectIds = projectIds.concat(projectId);
-    updateFreelancerApprovalMutation.mutate({ userId, projectId, endDate });
-    deleteVolunteerAndPendingFreelancerMutation.mutate(projectId);
+    const customVolunteers = volunteer.filter((v) => v !== userId);
+    updateFreelancerApprovalMutation.mutate({
+      userId,
+      projectId,
+      endDate,
+    });
+    deleteVolunteerAndPendingFreelancerMutation.mutate({
+      projectId,
+      updateVolunteer: customVolunteers,
+      updatePendingFreelancer: pendingFreelancer,
+    });
     addProjectIdToUserMutation.mutate({ userId, projectIds: customProjectIds });
     alert("승인이 완료되었습니다.");
     setIsModalOpen(false);
@@ -45,9 +54,7 @@ const ApplicantFreelancerList = () => {
     pendingFreelancer: string[],
     freelancerId: string
   ) => {
-    const updateVolunteerData = volunteer.filter(
-      (user) => user !== freelancerId
-    );
+    const updateVolunteerData = volunteer.filter((user) => user !== freelancerId);
     const updatePendingFreelancerData = pendingFreelancer.concat(freelancerId);
     updatePendingFreelancerMutation.mutate({
       projectId,
@@ -78,15 +85,11 @@ const ApplicantFreelancerList = () => {
                   <S.WorkFieldAndWorkExp>
                     {freelancer.workField?.workSmallField}
                   </S.WorkFieldAndWorkExp>
-                  <S.WorkFieldAndWorkExp>
-                    {freelancer.workExp}년차
-                  </S.WorkFieldAndWorkExp>
+                  <S.WorkFieldAndWorkExp>{freelancer.workExp}년차</S.WorkFieldAndWorkExp>
                 </S.ListContents>
                 <S.ProjectContents>
                   <div key={project.projectId}>
-                    <S.ProjectTitle>
-                      {project.title} 프로젝트에 지원
-                    </S.ProjectTitle>
+                    <S.ProjectTitle>{project.title} 프로젝트에 지원</S.ProjectTitle>
                   </div>
 
                   <S.CheckingBtn
@@ -110,7 +113,9 @@ const ApplicantFreelancerList = () => {
                                   freelancer.userId,
                                   project.projectId ?? "",
                                   project.date?.endDate as string,
-                                  freelancer.projectId || []
+                                  freelancer.projectId || [],
+                                  project.volunteer || [],
+                                  project.pendingFreelancer || []
                                 )
                               }
                             >
@@ -131,10 +136,7 @@ const ApplicantFreelancerList = () => {
                           </>
                         }
                       >
-                        <ApplicantFreelancerInfoModal
-                          user={freelancer}
-                          project={project}
-                        />
+                        <ApplicantFreelancerInfoModal user={freelancer} project={project} />
                       </Modal>
                     )}
                 </S.ProjectContents>

--- a/src/components/home/manageFreelancersByStatus/ApplicantFreelancerList.tsx
+++ b/src/components/home/manageFreelancersByStatus/ApplicantFreelancerList.tsx
@@ -80,6 +80,7 @@ const ApplicantFreelancerList = () => {
             project.volunteerUser?.map((freelancer) => (
               <S.List key={`${freelancer.userId}-${project.projectId}`}>
                 <S.ListContents>
+                  {project.freelancerId ? <div>모집완료</div> : <div>모집중</div>}
                   <S.FreelancerName>{freelancer.name}</S.FreelancerName>
                   <span>{freelancer.workField?.workField}</span>
                   <S.WorkFieldAndWorkExp>

--- a/src/components/home/manageFreelancersByStatus/PendingFreelancerList.tsx
+++ b/src/components/home/manageFreelancersByStatus/PendingFreelancerList.tsx
@@ -9,9 +9,7 @@ import useProjectsQueries from "../../../hooks/useProjectsQueries";
 
 const PendingFreelancerList = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [selectedFreelancer, setSelectedFreelancer] = useState<IUser | null>(
-    null
-  );
+  const [selectedFreelancer, setSelectedFreelancer] = useState<IUser | null>(null);
 
   const { userId } = useUserStore();
   const { client } = useClientsQueries({ userId });
@@ -29,11 +27,18 @@ const PendingFreelancerList = () => {
     userId: string,
     projectId: string,
     endDate: string,
-    projectIds: string[]
+    projectIds: string[],
+    volunteer: string[],
+    pendingFreelancer: string[]
   ) => {
     const customProjectIds = projectIds.concat(projectId);
+    const customPendingFreelancers = pendingFreelancer.filter((v) => v !== userId);
     updateFreelancerApprovalMutation.mutate({ userId, projectId, endDate });
-    deleteVolunteerAndPendingFreelancerMutation.mutate(projectId);
+    deleteVolunteerAndPendingFreelancerMutation.mutate({
+      projectId,
+      updateVolunteer: volunteer,
+      updatePendingFreelancer: customPendingFreelancers,
+    });
     addProjectIdToUserMutation.mutate({ userId, projectIds: customProjectIds });
     alert("승인이 완료되었습니다.");
     setIsModalOpen(false);
@@ -75,15 +80,11 @@ const PendingFreelancerList = () => {
                   <S.WorkFieldAndWorkExp>
                     {freelancer.workField?.workSmallField}
                   </S.WorkFieldAndWorkExp>
-                  <S.WorkFieldAndWorkExp>
-                    {freelancer.workExp}년차
-                  </S.WorkFieldAndWorkExp>
+                  <S.WorkFieldAndWorkExp>{freelancer.workExp}년차</S.WorkFieldAndWorkExp>
                 </S.ListContents>
                 <S.ProjectContents>
                   <div key={project.projectId}>
-                    <S.ProjectTitle>
-                      {project.title} 프로젝트에 지원
-                    </S.ProjectTitle>
+                    <S.ProjectTitle>{project.title} 프로젝트에 지원</S.ProjectTitle>
                   </div>
 
                   <S.CheckingBtn
@@ -107,7 +108,9 @@ const PendingFreelancerList = () => {
                                   freelancer.userId,
                                   project.projectId ?? "",
                                   project.date?.endDate as string,
-                                  freelancer.projectId || []
+                                  freelancer.projectId || [],
+                                  project.volunteer || [],
+                                  project.pendingFreelancer || []
                                 )
                               }
                             >
@@ -127,10 +130,7 @@ const PendingFreelancerList = () => {
                           </>
                         }
                       >
-                        <PendingFreelancerInfoModal
-                          user={freelancer}
-                          project={project}
-                        />
+                        <PendingFreelancerInfoModal user={freelancer} project={project} />
                       </Modal>
                     )}
                 </S.ProjectContents>

--- a/src/components/home/manageFreelancersByStatus/PendingFreelancerList.tsx
+++ b/src/components/home/manageFreelancersByStatus/PendingFreelancerList.tsx
@@ -75,6 +75,7 @@ const PendingFreelancerList = () => {
             project.pendingFreelancerUser?.map((freelancer) => (
               <S.List key={`${project.projectId}-${freelancer.userId}`}>
                 <S.ListContents>
+                  {project.freelancerId ? <div>모집완료</div> : <div>모집중</div>}
                   <S.FreelancerName>{freelancer.name}</S.FreelancerName>
                   <span>{freelancer.workField?.workField}</span>
                   <S.WorkFieldAndWorkExp>

--- a/src/components/modal/freelancerInfo/freelancerInfoStyle.ts
+++ b/src/components/modal/freelancerInfo/freelancerInfoStyle.ts
@@ -71,6 +71,7 @@ export const S = {
   `,
   Contacts: styled.span`
     display: flex;
+    width: 200px;
     font-size: 14px;
   `,
   PortfolioBox: styled.div`

--- a/src/components/myPage/client/listOfFreelancersByStatus/freelancerInfoModalByStatusStyle.ts
+++ b/src/components/myPage/client/listOfFreelancersByStatus/freelancerInfoModalByStatusStyle.ts
@@ -7,6 +7,7 @@ export const S = {
     margin-bottom: 20px;
   `,
   ProfileInfo: styled.div`
+    gap: 10px;
     display: flex;
     flex-direction: row;
     justify-content: space-around;

--- a/src/components/myPage/client/listOfFreelancersByStatus/listOfFreelancersByStatusStyle.ts
+++ b/src/components/myPage/client/listOfFreelancersByStatus/listOfFreelancersByStatusStyle.ts
@@ -103,7 +103,6 @@ export const S = {
   `,
   DetailBtn: styled.button`
     position: relative;
-    top: 50px;
     border: 1px solid #0086d0;
     border-radius: 4px;
     width: 90%;

--- a/src/hooks/useProjectsQueries.ts
+++ b/src/hooks/useProjectsQueries.ts
@@ -99,29 +99,21 @@ const useProjectsQueries = ({
     {
       enabled: !!currentUserId,
       select: (allProjectList) =>
-        allProjectList?.filter((project) =>
-          project.SuggestedFreelancers?.includes(currentUserId)
-        ),
+        allProjectList?.filter((project) => project.SuggestedFreelancers?.includes(currentUserId)),
     }
   );
 
-  const addProjectMutation = useMutation(
-    (newProject: Project) => addProject(newProject),
-    {
-      onSuccess: () => {
-        queryClient.invalidateQueries(["projects"]);
-      },
-    }
-  );
+  const addProjectMutation = useMutation((newProject: Project) => addProject(newProject), {
+    onSuccess: () => {
+      queryClient.invalidateQueries(["projects"]);
+    },
+  });
 
-  const deleteProjectMutation = useMutation(
-    (projectId: string) => deleteProject(projectId),
-    {
-      onSuccess: () => {
-        queryClient.invalidateQueries(["projects"]);
-      },
-    }
-  );
+  const deleteProjectMutation = useMutation((projectId: string) => deleteProject(projectId), {
+    onSuccess: () => {
+      queryClient.invalidateQueries(["projects"]);
+    },
+  });
 
   const updateProjectMutation = useMutation(
     ({ projectId, newProject }: { projectId: string; newProject: Project }) =>
@@ -147,8 +139,7 @@ const useProjectsQueries = ({
       enabled: !!currentUserId,
       select: (projectLists) =>
         projectLists?.filter(
-          (projectList) =>
-            !projectList.SuggestedFreelancers?.includes(freelancerId as string)
+          (projectList) => !projectList.SuggestedFreelancers?.includes(freelancerId as string)
         ),
     }
   );
@@ -257,8 +248,7 @@ const useProjectsQueries = ({
       projectId: string;
       updateVolunteer: string[];
       pendingFreelancer: string[];
-    }) =>
-      updatePendingFreelancer(projectId, updateVolunteer, pendingFreelancer),
+    }) => updatePendingFreelancer(projectId, updateVolunteer, pendingFreelancer),
     {
       onSuccess: () => {
         queryClient.invalidateQueries(["applicantFreelancers"]);
@@ -267,15 +257,8 @@ const useProjectsQueries = ({
   );
 
   const updateFreelancerApprovalMutation = useMutation(
-    ({
-      userId,
-      projectId,
-      endDate,
-    }: {
-      userId: string;
-      projectId: string;
-      endDate: string;
-    }) => updateApprovalFreelancer(userId, projectId, endDate),
+    ({ userId, projectId, endDate }: { userId: string; projectId: string; endDate: string }) =>
+      updateApprovalFreelancer(userId, projectId, endDate),
     {
       onSuccess: () => {
         queryClient.invalidateQueries(["applicantFreelancers"]);
@@ -311,22 +294,27 @@ const useProjectsQueries = ({
   );
 
   const deleteVolunteerAndPendingFreelancerMutation = useMutation(
-    (projectId: string) => deleteVolunteerAndPendingFreelancer(projectId),
+    ({
+      projectId,
+      updateVolunteer,
+      updatePendingFreelancer,
+    }: {
+      projectId: string;
+      updateVolunteer: string[];
+      updatePendingFreelancer: string[];
+    }) => deleteVolunteerAndPendingFreelancer(projectId, updateVolunteer, updatePendingFreelancer),
     {
       onSuccess: () => {
         queryClient.invalidateQueries(["applicantFreelancers"]);
+        queryClient.invalidateQueries(["pendingFreelancers"]);
       },
     }
   );
 
-  const { data: ongoingProjectsWithFreelancers } = useQuery<
-    IProjectWithFreelancer[]
-  >(
+  const { data: ongoingProjectsWithFreelancers } = useQuery<IProjectWithFreelancer[]>(
     ["ongoingProjectsWithFreelancers"],
     async () => {
-      const ongoingProjectsData = await getOngoingProjects(
-        currentUserId as string
-      );
+      const ongoingProjectsData = await getOngoingProjects(currentUserId as string);
       const ongoingProjectsWithPromise = ongoingProjectsData.map((info) => ({
         ...info,
         freelancerPromise: getUser(info.freelancerId as string),
@@ -345,20 +333,14 @@ const useProjectsQueries = ({
     }
   );
 
-  const { data: terminationedProjectsWithFreelancers } = useQuery<
-    IProjectWithFreelancer[]
-  >(
+  const { data: terminationedProjectsWithFreelancers } = useQuery<IProjectWithFreelancer[]>(
     ["terminationedProjectsWithFreelancers"],
     async () => {
-      const terminationedProjectsData = await getTerminationedProjects(
-        currentUserId as string
-      );
-      const terminationedProjectsWithPromise = terminationedProjectsData.map(
-        (info) => ({
-          ...info,
-          freelancerPromise: getUser(info.freelancerId as string),
-        })
-      );
+      const terminationedProjectsData = await getTerminationedProjects(currentUserId as string);
+      const terminationedProjectsWithPromise = terminationedProjectsData.map((info) => ({
+        ...info,
+        freelancerPromise: getUser(info.freelancerId as string),
+      }));
       const terminationedProjectsWithFreelancers = await Promise.all(
         terminationedProjectsWithPromise.map(async (project) => ({
           ...project,
@@ -375,11 +357,10 @@ const useProjectsQueries = ({
   const { data: matchingCompletedProjectsData } = useQuery(
     ["matchingCompletedProjectsData"],
     async () => {
-      const terminationedProjects =
-        await getTerminationedProjectsWithFreelancer(
-          currentUserId as string,
-          freelancerId as string
-        );
+      const terminationedProjects = await getTerminationedProjectsWithFreelancer(
+        currentUserId as string,
+        freelancerId as string
+      );
       if (!terminationedProjects) {
         return [];
       }


### PR DESCRIPTION
## 작업사항 📝 
- 프리랜서 계약 시 지원한 프리랜서, 보류한 프리랜서, 제안한 프리랜서 칼럼 값 삭제 목록 복구
- 프리랜서 계약 시 지원한 프리랜서 & 보류한 프리랜서 탭에서 계약한 프리랜서 정보만 삭제 되도록 수정
- 지원한 프리랜서 & 보류한 프리랜서 탭 -> 프로젝트 모집 상태 추가 (모집중 / 모집완료)
## 패키지 설치내용 📦 
x