### PR TITLE
fix - Disabled visibility of commited freelancers in the detail project modal for freelancer

### DIFF
--- a/src/components/projectManagement/projectList/ProjectDetailModal.tsx
+++ b/src/components/projectManagement/projectList/ProjectDetailModal.tsx
@@ -3,6 +3,7 @@ import S from "./ProjectListStyles";
 import { useEffect, useState } from "react";
 import { getFreelancer } from "src/api/User";
 import ProjectCommittedFreelancerProfile from "./ProjectCommittedFreelancerProfile";
+import { useUserStore } from "src/zustand/useUserStore";
 
 export interface ProjectDetailModalProps {
   project: Project;
@@ -25,6 +26,8 @@ export interface FreelancerInfo {
 const ProjectDetailModal = ({ project }: ProjectDetailModalProps) => {
   const [committedFreelancer, setCommittedFreelancer] =
     useState<FreelancerInfo | null>(null);
+
+  const { userRole } = useUserStore();
 
   const fetchCommittedFreelancer = async () => {
     const userId = project.freelancerId!;
@@ -148,7 +151,7 @@ const ProjectDetailModal = ({ project }: ProjectDetailModalProps) => {
       </S.ModalInfoColumnBox>
       {/* --------------------------------------------------------- */}
 
-      {committedFreelancer && (
+      {committedFreelancer && userRole === "client" && (
         <>
           <S.ModalLine />
           <S.ModalTitle marginBottom="10px">


### PR DESCRIPTION
## 작업사항 📝

- 모집 완료된 프로젝트의 투입한 프리랜서 정보를 다른 프리랜서가 보지 못하도록 수정

## 패키지 설치내용 📦

x